### PR TITLE
Update README.md with exposed ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ All images built for `linux/amd64` and `linux/arm64`
 | `WEBGRIND_MOUNTED_CODEBASE_PATH` | `/mnt/codebase`     |             |
 
 See [wodby/php](https://github.com/wodby/php) for more variables
+
+## Exposed ports
+
+This image exposes the port 8080 for the webgrind webserver.


### PR DESCRIPTION
Hi,
Just thought that rather than submit an issue for a README fix, I could just submit a PR instead.

Proposed wording is just placeholder for something to indicate to the user what port they should be able to access the web app in.

I had to dig into the Dockerfile to find out what port was exposed, just now so that I could remap it.